### PR TITLE
Restore freelance nav link and remove wallet from footer

### DIFF
--- a/src/components/layout/FooterNav.tsx
+++ b/src/components/layout/FooterNav.tsx
@@ -27,6 +27,14 @@ const FooterNav = () => {
       active: location.pathname === "/app/explore",
     },
     {
+      icon: Briefcase,
+      label: "Freelance",
+      href: "/app/freelance",
+      active:
+        location.pathname === "/app/freelance" ||
+        location.pathname.startsWith("/app/freelance"),
+    },
+    {
       icon: Video,
       label: "Videos",
       href: "/app/videos",
@@ -47,14 +55,6 @@ const FooterNav = () => {
       active:
         location.pathname === "/app/crypto" ||
         location.pathname.startsWith("/app/crypto"),
-    },
-    {
-      icon: Briefcase,
-      label: "Freelance",
-      href: "/app/freelance",
-      active:
-        location.pathname === "/app/freelance" ||
-        location.pathname.startsWith("/app/freelance"),
     },
   ];
 

--- a/src/components/layout/FooterNav.tsx
+++ b/src/components/layout/FooterNav.tsx
@@ -5,7 +5,7 @@ import {
   Video,
   ShoppingCart,
   TrendingUp,
-  Wallet,
+  Briefcase,
 } from "lucide-react";
 import { cn } from "@/utils/utils";
 import { Button } from "@/components/ui/button";
@@ -49,10 +49,12 @@ const FooterNav = () => {
         location.pathname.startsWith("/app/crypto"),
     },
     {
-      icon: Wallet,
-      label: "Wallet",
-      href: "/app/wallet",
-      active: location.pathname === "/app/wallet",
+      icon: Briefcase,
+      label: "Freelance",
+      href: "/app/freelance",
+      active:
+        location.pathname === "/app/freelance" ||
+        location.pathname.startsWith("/app/freelance"),
     },
   ];
 


### PR DESCRIPTION
## Purpose

The user requested to restore the freelance navigation link to the footer navigation bar and remove the unified wallet navigation link. The wallet functionality should remain accessible through the Facebook-style side menu. The correct footer navigation order should be: feed, explore, freelance, videos, market, crypto.

## Code changes

- **Added freelance navigation item**: Restored the "Freelance" link with Briefcase icon pointing to `/app/freelance` with proper active state handling
- **Removed wallet navigation item**: Eliminated the "Wallet" link with Wallet icon from the footer navigation
- **Updated imports**: Changed from `Wallet` to `Briefcase` icon import from lucide-react
- **Maintained navigation order**: Ensured the footer follows the requested sequence of navigation itemsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 198`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f2c8eebcc0d0406094f07ffe931ea1cf/spark-garden)

👀 [Preview Link](https://f2c8eebcc0d0406094f07ffe931ea1cf-spark-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f2c8eebcc0d0406094f07ffe931ea1cf</projectId>-->
<!--<branchName>spark-garden</branchName>-->